### PR TITLE
Git describe tag set to empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,7 @@ runs:
         echo "::group::Conda packages building"
         export PYTHON_VERSION="3.${{ inputs.python }}"
         export NUMPY_VERSION=${{ steps.numpy-selection.outputs.numpy_version }}
-        export GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0)
+        export GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0 | sed 's/v//')
         out_dir=`mktemp -d conda-build-dir.XXXXXX`
         echo "Running 'conda build' with python ${PYTHON_VERSION} and numpy ${NUMPY_VERSION} and git version tag ${GIT_DESCRIBE_TAG}"
         conda build . --output-folder $out_dir --python=${PYTHON_VERSION} --numpy=${NUMPY_VERSION} ${{ inputs.buildoptions }}

--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,7 @@ runs:
         echo "::group::Conda packages building"
         export PYTHON_VERSION="3.${{ inputs.python }}"
         export NUMPY_VERSION=${{ steps.numpy-selection.outputs.numpy_version }}
-        export GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0 | sed 's/v//')
+        export GIT_DESCRIBE_TAG=""
         out_dir=`mktemp -d conda-build-dir.XXXXXX`
         echo "Running 'conda build' with python ${PYTHON_VERSION} and numpy ${NUMPY_VERSION} and git version tag ${GIT_DESCRIBE_TAG}"
         conda build . --output-folder $out_dir --python=${PYTHON_VERSION} --numpy=${NUMPY_VERSION} ${{ inputs.buildoptions }}


### PR DESCRIPTION
While testing further GIT_DESCRIBE_TAG behavior, we realize that conda actualy fill this variable,....only when there is a tag. This is however not the case when testing a branch with fetch-depth=0 (default in actions), and CI failed in this case. When a tag is set, the GIT_DESCRIBE_TAG created by conda takes precedence. To avoid confusion, I suggest to set GIT_DESCRIBE_TAG to empty string, as this variable will never be used, but is there only to allow CI pass when there is no tags.

In addition, we realive that GIT_DESCRIBE_TAG returns the 'v' prefix, that can cause conda latest version detection to be messy if there is a mix of 'vx.x.x" and 'x.x.x' tags (latest conda package is in alphanumeric order). Removal of the 'v' should however be done in meta.yaml (see update of my pull request on doc or in astk) and not in action.